### PR TITLE
结构体: 数组值增强, 应用于 `@var Struct[]`、`@var string[]` 类的注释；

### DIFF
--- a/src/Property.php
+++ b/src/Property.php
@@ -177,6 +177,19 @@ class Property
         return $this->booleanType;
     }
 
+    /**
+     * 是否允许为空
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return $this->rule['empty'];
+    }
+
+    /**
+     * 是否为Money类型
+     * @return bool
+     */
     public function isMoney()
     {
         return $this->moneyType;
@@ -184,7 +197,7 @@ class Property
 
     /**
      * 属性值是否必填
-     * @return mixed
+     * @return bool
      */
     public function isRequired()
     {


### PR DESCRIPTION
1. 若赋值为空字符串、NULL类型时自动转成空数组
2. 使用@Valicator(empty=false), 可以控制目标数组至少需要1个合法记录;
    例如: 订单入参至少需要一个商品记录